### PR TITLE
Mailing of Password Reset Request and Fixes on Approval Modal (VAM)

### DIFF
--- a/src/includes/classes/email-sender.php
+++ b/src/includes/classes/email-sender.php
@@ -55,6 +55,36 @@ class EmailSender
         return $this->sendEmail($recipientEmail, $subject, $mailBody);
     }
 
+    public function sendPasswordResetEmail($recipientEmail, $token) {
+        $subject = 'iVOTE Password Reset Request';
+        $mailBody = <<<EOT
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>iVOTE Password Reset Request</title>
+        </head>
+        <body">
+            <p>Dear Iskolar,</p>
+            <p>We have received a request to reset the password associated with your account. To complete the process, 
+            please follow the instructions below:</p>
+            <ul style="padding-left: 20px;">
+                <li>Click on the following link to reset your password: <a href="http://localhost/PUPSRC-AutomatedElectionSystem/src/reset-password.php?token=$token">Reset Password Link</a></li>
+                <li>The password reset link is only available for 30 minutes.</li>
+                <li>If you are unable to click the link above, please copy and paste it into your browser's address bar.</li>
+                <li>Once the link opens, you will be prompted to enter a new password for your account. Please choose a strong and secure password to ensure the safety of your account.</li>
+            </ul>
+            <p>If you did not initiate this password reset request, please disregard this email.</p>
+            <p>Thank you for your attention to this matter.</p>
+            <p>Best regards,<br>iVOTE Team</p>
+        </body>
+        </html>
+        EOT;
+    
+        return $this->sendEmail($recipientEmail, $subject, $mailBody);
+    }
+    
 
     private function sendEmail($recipientEmail, $subject, $body)
     {

--- a/src/includes/classes/landing-page-controller.php
+++ b/src/includes/classes/landing-page-controller.php
@@ -17,9 +17,16 @@ class LandingPageController {
                 exit();
             }
             else {
+                if(isset($_SESSION['organization'])) {
+                    if($clicked_org != $_SESSION['organization']) {
+                        $_SESSION['error_message'] = 'Your session is already set to ' . strtoupper($_SESSION['organization']) . '.';
+                        header("Location: ../../voter-login.php");
+                        exit();                        
+                    }
+                }
                 $_SESSION['organization'] = $clicked_org;
                 header("Location: ../../voter-login.php");
-                exit();       
+                exit();                        
             }
         }
         else {

--- a/src/includes/classes/voter-login-class.php
+++ b/src/includes/classes/voter-login-class.php
@@ -122,11 +122,11 @@ class Login{
             }
         } 
         else {
+            unsetSessionVar();
             $_SESSION['error_message'] = 'Something went wrong.';
+            header("Location: ../voter-login.php");
             exit();
         }
-        header("Location: ../voter-login.php");
-        exit();
     }
 
     // Redirects a committee member to the admin dashboard

--- a/src/includes/session-handler.php
+++ b/src/includes/session-handler.php
@@ -1,31 +1,31 @@
 <?php
 
-ini_set('session.use_only_cookies', 1);
-ini_set('session.use_strict_mode', 1);
+// ini_set('session.use_only_cookies', 1);
+// ini_set('session.use_strict_mode', 1);
 
-session_set_cookie_params([
-    'lifetime' => 1800,
-    'domain' => 'localhost',
-    'path' => '/',
-    'secure' => true,
-    'httponly' => true
-]);
+// session_set_cookie_params([
+//     'lifetime' => 1800,
+//     'domain' => 'localhost',
+//     'path' => '/',
+//     'secure' => true,
+//     'httponly' => true
+// ]);
 
 session_start();
 
-if (!isset($_SESSION['last_regeneration'])) {
-    regenerateSessionId();
-} else {
-    $interval = 1800;
-    if (time() - $_SESSION['last_regeneration'] >= $interval) {
-        regenerateSessionId();
-    }
-}
+// if (!isset($_SESSION['last_regeneration'])) {
+//     regenerateSessionId();
+// } else {
+//     $interval = 1800;
+//     if (time() - $_SESSION['last_regeneration'] >= $interval) {
+//         regenerateSessionId();
+//     }
+// }
 
-function regenerateSessionId() {
-    if (session_status() !== PHP_SESSION_ACTIVE) {
-        session_start();
-    }
-    session_regenerate_id(true);
-    $_SESSION['last_regeneration'] = time();
-}
+// function regenerateSessionId() {
+//     if (session_status() !== PHP_SESSION_ACTIVE) {
+//         session_start();
+//     }
+//     session_regenerate_id(true);
+//     $_SESSION['last_regeneration'] = time();
+// }

--- a/src/includes/voter-login-inc.php
+++ b/src/includes/voter-login-inc.php
@@ -40,7 +40,7 @@ if($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST['sign-in'])) {
 }
 
 function displayUnsetToken() {
-    $_SESSION['error_message'] = 'Something went wrong. Please reload the page.';
+    $_SESSION['error_message'] = 'Something went wrong.<br/>Please reload the page.';
     header("Location: ../voter-login.php");
     exit();
 }

--- a/src/includes/voter-logout.php
+++ b/src/includes/voter-logout.php
@@ -5,10 +5,8 @@ require_once FileUtils::normalizeFilePath('error-reporting.php');
 
 $referer = $_SERVER['HTTP_REFERER'];
 if ($referer && strpos($referer, $_SERVER['HTTP_HOST']) !== false) {
-
-    // Kill only the session of logged-in user
-    // Retain the session of which database organization a user is connected
-    unset($_SESSION['voter_id']);
+    
+    session_destroy();
     
     // Redirect back to previously stored URL
     if (isset($_SESSION['return_to'])) {

--- a/src/landing-page.php
+++ b/src/landing-page.php
@@ -8,6 +8,7 @@ include_once FileUtils::normalizeFilePath('includes/organization-list.php');
 // Check if voter_id and role is set in session
 SessionManager::checkUserRoleAndRedirect();
 unsetSessionVar();
+unset($_SESSION['organization']);
 
 ?>
 

--- a/src/submission_handlers/validate-acc.php
+++ b/src/submission_handlers/validate-acc.php
@@ -23,7 +23,6 @@ if (isset($_POST['voter_id'])) {
         // Sending of email
         $recipientEmail = $voter->getEmailById($voter_id);
         $emailSender->sendApprovalEmail($recipientEmail);
-        $conn->close();
 
     } elseif ($action == 'reject') {
 
@@ -36,7 +35,6 @@ if (isset($_POST['voter_id'])) {
         $reason = isset($_POST['reason']) ? $_POST['reason'] : '';
         $otherReason = isset($_POST['otherReason']) ? $_POST['otherReason'] : '';
         $emailSender->sendRejectionEmail($recipientEmail, $reason, $otherReason);
-        $conn->close();
     }
 
     echo json_encode(['success' => true]);

--- a/src/voter-login.php
+++ b/src/voter-login.php
@@ -112,14 +112,21 @@ if (isset($_SESSION['info_message'])) {
 
                         <div class="col-md-12 mt-0 mb-3">
                             <input type="email" class="form-control" id="Email" name="email" onkeypress="return avoidSpace(event)" placeholder="Email Address" required pattern="[a-zA-Z0-9._%+-]+@gmail\.com$" value="<?php if (isset($_SESSION['email'])) echo $_SESSION['email']; ?>">
+                            <div class="ps-2 text-start invalid-feedback">
+                                Please provide a valid email.
+                            </div>
                         </div>
 
                         <div class="col-md-12 mb-2">
                             <div class="input-group">
                                 <input type="password" class="form-control" name="password" onkeypress="return avoidSpace(event)" placeholder="Password" value="<?php if (isset($_SESSION['password'])) echo $_SESSION['password']; ?>" id="Password" required>
                                 <button class="btn" type="button" id="password-toggle">Show</button>
+                                <!-- <div class="ps-2 text-start invalid-feedback">
+                                    Please provide a valid password.
+                                </div> -->
                             </div>
                         </div>
+                        
                         <a href="forgot-password.php" class="text-align-start" data-bs-toggle="modal" data-bs-target="#forgot-password-modal" id="forgot-password">Forgot Password</a>
 
                         <div class="d-grid gap-2 mt-5 mb-4">
@@ -225,6 +232,26 @@ if (isset($_SESSION['info_message'])) {
             var k = event ? event.which : window.event.keyCode;
             if (k == 32) return false;
         }
+
+        // Example starter JavaScript for disabling form submissions if there are invalid fields
+        (() => {
+        'use strict'
+
+        // Fetch all the forms we want to apply custom Bootstrap validation styles to
+        const forms = document.querySelectorAll('.needs-validation')
+
+        // Loop over them and prevent submission
+        Array.from(forms).forEach(form => {
+            form.addEventListener('submit', event => {
+            if (!form.checkValidity()) {
+                event.preventDefault()
+                event.stopPropagation()
+            }
+
+            form.classList.add('was-validated')
+            }, false)
+        })
+        })()
     </script>
 
 </body>

--- a/src/voter-login.php
+++ b/src/voter-login.php
@@ -14,14 +14,12 @@ $_SESSION['csrf_expiry'] = time() + (60 * 30);
 
 if (isset($_SESSION['error_message'])) {
     $error_message = $_SESSION['error_message'];
-    // Unset the error message from the session once displayed
-    unset($_SESSION['error_message']);
+    unset($_SESSION['error_message']); // Unset the error message from the session once displayed
 }
 
 if (isset($_SESSION['info_message'])) {
-    $info_message = $_SESSION['info_message'];
-    // Unset the info message from the session once displayed
-    unset($_SESSION['info_message']);
+    $info_message = $_SESSION['info_message'];    
+    unset($_SESSION['info_message']); // Unset the info message from the session once displayed
 }
 
 ?>


### PR DESCRIPTION
## FIXES

1. Removed undefined variable $conn causing an error of not displaying the approval modal during voters account validation. Asking review and contingent approval by the concerned developer of this bugfix @biellamariscotes 

2. Removed the organization set in session when the user is on the landing page.

## FEATURES

1. Can now send the proper email instructions to a user requesting a password reset through the forgot password feature.

![image](https://github.com/BSIT-3-1-APPDEV/PUPSRC-AutomatedElectionSystem/assets/162773681/c5e6189f-bc59-43f2-9508-2c4daf5170c0)


## CHORES

1. Commented out codes on `session-handler.php` due to the unsolved issue of unwanted logged-outs