### PR TITLE
Fix: Organization Not Set in Session on Reset Password Page

### DIFF
--- a/src/includes/classes/email-sender.php
+++ b/src/includes/classes/email-sender.php
@@ -55,8 +55,9 @@ class EmailSender
         return $this->sendEmail($recipientEmail, $subject, $mailBody);
     }
 
-    public function sendPasswordResetEmail($recipientEmail, $token) {
+    public function sendPasswordResetEmail($recipientEmail, $token, $orgName) {
         $subject = 'iVOTE Password Reset Request';
+        $resetPasswordLink = "http://localhost/PUPSRC-AutomatedElectionSystem/src/reset-password.php?token=$token&orgName=$orgName";
         $mailBody = <<<EOT
         <!DOCTYPE html>
         <html lang="en">
@@ -70,7 +71,7 @@ class EmailSender
             <p>We have received a request to reset the password associated with your account. To complete the process, 
             please follow the instructions below:</p>
             <ul style="padding-left: 20px;">
-                <li>Click on the following link to reset your password: <a href="http://localhost/PUPSRC-AutomatedElectionSystem/src/reset-password.php?token=$token">Reset Password Link</a></li>
+                <li>Click on the following link to reset your password: <a href="$resetPasswordLink">Reset Password Link</a></li>
                 <li>The password reset link is only available for 30 minutes.</li>
                 <li>If you are unable to click the link above, please copy and paste it into your browser's address bar.</li>
                 <li>Once the link opens, you will be prompted to enter a new password for your account. Please choose a strong and secure password to ensure the safety of your account.</li>

--- a/src/scripts/reset-password.js
+++ b/src/scripts/reset-password.js
@@ -1,0 +1,29 @@
+// Updated script for password toggle
+document.addEventListener("DOMContentLoaded", function () {
+  const togglePassword1 = document.querySelector("#reset-password-toggle-1");
+  const togglePassword2 = document.querySelector("#reset-password-toggle-2");
+  const passwordInput1 = document.querySelector("#password");
+  const passwordInput2 = document.querySelector("#password_confirmation");
+  const eyeIcon1 = togglePassword1.querySelector("i");
+  const eyeIcon2 = togglePassword2.querySelector("i");
+
+  togglePassword1.addEventListener("click", function () {
+    const type =
+      passwordInput1.getAttribute("type") === "password" ? "text" : "password";
+    passwordInput1.setAttribute("type", type);
+
+    // Toggle eye icon classes
+    eyeIcon1.classList.toggle("fa-eye-slash");
+    eyeIcon1.classList.toggle("fa-eye");
+  });
+
+  togglePassword2.addEventListener("click", function () {
+    const type =
+      passwordInput2.getAttribute("type") === "password" ? "text" : "password";
+    passwordInput2.setAttribute("type", type);
+
+    // Toggle eye icon classes
+    eyeIcon2.classList.toggle("fa-eye-slash");
+    eyeIcon2.classList.toggle("fa-eye");
+  });
+});

--- a/src/scripts/voter-login.js
+++ b/src/scripts/voter-login.js
@@ -1,0 +1,44 @@
+// Updated script for password toggle
+document.addEventListener("DOMContentLoaded", function () {
+  const togglePassword = document.querySelector("#password-toggle");
+  const passwordInput = document.querySelector("#Password");
+
+  togglePassword.addEventListener("click", function () {
+    const type =
+      passwordInput.getAttribute("type") === "password" ? "text" : "password";
+    passwordInput.setAttribute("type", type);
+
+    // Change button text
+    togglePassword.textContent = type === "password" ? "Show" : "Hide";
+  });
+});
+
+// Disallow whitespaces from input fields
+function avoidSpace(event) {
+  if (event.key === " ") {
+    event.preventDefault();
+  }
+}
+
+(() => {
+  "use strict";
+
+  // Fetch all the forms we want to apply custom Bootstrap validation styles to
+  const forms = document.querySelectorAll(".needs-validation");
+
+  // Loop over them and prevent submission
+  Array.from(forms).forEach((form) => {
+    form.addEventListener(
+      "submit",
+      (event) => {
+        if (!form.checkValidity()) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+
+        form.classList.add("was-validated");
+      },
+      false
+    );
+  });
+})();

--- a/src/voter-login.php
+++ b/src/voter-login.php
@@ -150,29 +150,26 @@ if (isset($_SESSION['info_message'])) {
             <div class="modal-content">
                 <div class="m justify-content-center">
                     <h1 class="modal-title fs-5 fw-bold" id="<?php echo strtolower($org_name); ?>SignUP">Forgot Password
-                    </h1>
+                    </h1><hr>
                 </div>
                 <div class="modal-body">
                     <form action="includes/send-password-reset.php" method="post" class="needs-validation" id="forgot-password-form" name="forgot-password-form" novalidate enctype="multipart/form-data">
                         <div class="col-12 col-md-12">
-                            <div class="d-flex align-items-start">
-                                <label for="email" class="form-label">Email Address</label>
+                            <div class="d-flex align-items-start mb-3">
+                                <p for="email" class="form-label text-start ps-1">We will send a password reset link to your registered email address.</p>
                             </div>
-                            <input type="text" class="form-control" name="email" id="email" required pattern="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$" oninvalid="this.setCustomValidity('Please enter a valid email address')" oninput="this.setCustomValidity('')" />
-                            <div class="valid-feedback text-start">Looks good!</div>
-                            <div class="invalid-feedback">
-                                Please enter a valid email address.
+                            <input type="email" class="form-control" id="email" name="email" onkeypress="return avoidSpace(event)" placeholder="Email Address" required pattern="[a-zA-Z0-9._%+-]+@gmail\.com$">
+                            <div class="invalid-feedback text-start">
+                                Please provide a valid email.
                             </div>
                         </div>
-                        <div id="email-sent-message" class="email-confirmation mt-2">Kindly check your email. An email has
-                        been sent.</div>
                         <div class="col-md-12 ">
                             <div class="row reset-pass">
-                                <div class="col-4">
-                                    <button  type="button" class="btn cancel-button w-100 mt-4" data-bs-dismiss="modal">Cancel</button>
+                                <div class="col-4"> 
+                                    <button  type="button" id="sendPasswordResetLink" class="btn cancel-button w-100 mt-4" data-bs-dismiss="modal">Cancel</button>
                                 </div>
                                 <div class="col-4">
-                                    <button class="btn login-sign-in-button w-100 mt-4" id="<?php echo strtoupper($org_name); ?>-login-button" type="submit" name="send-email-btn" onclick="showEmailSentMessage()">Send</button>
+                                    <button class="btn login-sign-in-button w-100 mt-4" id="<?php echo strtoupper($org_name); ?>-login-button" type="submit" name="send-email-btn">Send</button>
                                 </div>
                             </div>
                         </div>
@@ -183,78 +180,8 @@ if (isset($_SESSION['info_message'])) {
         </div>
     </div>
 
-
-    <!-- Disabled and enables the send button -->
-    <script>
-        const form = document.querySelector('form[name="forgot-password-form"]');
-        const submitBtn = form.querySelector('button[name="send-email-btn"]');
-
-        submitBtn.disabled = true;
-
-    
-        form.addEventListener('input', function() {
-            if (form.checkValidity()) {
-
-                submitBtn.disabled = false;
-            } else {
-                submitBtn.disabled = true;
-            }
-        });
-    </script>
-
-        <!-- Message when clicking the send button -->
-    <script>
-        function showEmailSentMessage() {
-            document.getElementById("email-sent-message").style.display = "block";
-        }
-    </script>
-
     <script src="../vendor/node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
-
-    <!-- Updated script for password toggle -->
-    <script>
-        document.addEventListener("DOMContentLoaded", function() {
-            const togglePassword = document.querySelector("#password-toggle");
-            const passwordInput = document.querySelector("#Password");
-
-            togglePassword.addEventListener("click", function() {
-                const type =
-                    passwordInput.getAttribute("type") === "password" ?
-                    "text" :
-                    "password";
-                passwordInput.setAttribute("type", type);
-
-                // Change button text
-                togglePassword.textContent = type === "password" ? "Show" : "Hide";
-            });
-        });
-
-        // Disallow whitespaces from input fields
-        function avoidSpace(event) {
-            var k = event ? event.which : window.event.keyCode;
-            if (k == 32) return false;
-        }
-
-        // Example starter JavaScript for disabling form submissions if there are invalid fields
-        (() => {
-        'use strict'
-
-        // Fetch all the forms we want to apply custom Bootstrap validation styles to
-        const forms = document.querySelectorAll('.needs-validation')
-
-        // Loop over them and prevent submission
-        Array.from(forms).forEach(form => {
-            form.addEventListener('submit', event => {
-            if (!form.checkValidity()) {
-                event.preventDefault()
-                event.stopPropagation()
-            }
-
-            form.classList.add('was-validated')
-            }, false)
-        })
-        })()
-    </script>
+    <script src="scripts/voter-login.js"></script>
 
 </body>
 


### PR DESCRIPTION
# REFACTOR

1. JavaScript of the login and reset password page were separated and moved into new files.
2. These javascript files were then added to the `scripts` folder.

# FIX

1. Add the org name to the link/URL sent to the user for password recovery.

    - This ensures that even if the user has closed his tab, gone to the landing page, or any actions that will unset the session of the organization, he will be redirected to his respective organization reset password page upon clicking the link sent through email.

# MISC

1. Add client-side validation on the forgot password modal.

# MAJOR BUG [unresolved]

1. When sending an email, the send button can be clicked repeatedly while the sending of the email is ongoing, causing the user to receive multiple emails of the same type.