### PR TITLE
Add 'Only PDF Files Allowed' Modal To Registration

### DIFF
--- a/src/register.php
+++ b/src/register.php
@@ -199,7 +199,7 @@ if ($result->num_rows > 0) {
                 <div class="modal-body">
                     <div class="d-flex justify-content-end">
                         <i class="fa fa-solid fa-circle-xmark fa-xl close-mark light-gray"
-                            onclick="redirectToPage('landing-page.php')" id="close-modal">
+                            onclick="redirectToPage('landing-page.php')">
                         </i>
                     </div>
                     <div class="text-center">

--- a/src/register.php
+++ b/src/register.php
@@ -182,13 +182,21 @@ if ($result->num_rows > 0) {
             </div>
         </div>
     </div>
-    <div class="modal" id="approvalModal" tabindex="-1" role="dialog">
+
+    <button class="del-no-border px-sm-5 py-sm-1-5 btn-sm fw-bold fs-6 spacing-6" id="reject-btn" data-toggle="modal"
+        data-target="#onlyPDFAllowedModal">Try Only PDF files Button</button>
+
+
+    <!-- LIST OF MODALS -->
+
+    <!-- Registered Successfully Modal -->
+    <div class="modal" id="approvalModal" data-bs-keyboard="false" data-bs-backdrop="static">
         <div class="modal-dialog modal-dialog-centered" role="document">
             <div class="modal-content">
                 <div class="modal-body">
                     <div class="d-flex justify-content-end">
                         <i class="fa fa-solid fa-circle-xmark fa-xl close-mark light-gray"
-                            onclick="redirectToPage('landing-page.php')">
+                            onclick="redirectToPage('landing-page.php')" id="close-modal">
                         </i>
                     </div>
                     <div class="text-center">
@@ -199,7 +207,8 @@ if ($result->num_rows > 0) {
                         <div class="row">
                             <div class="col-md-12 pb-3">
                                 <p class="fw-bold fs-3 success-color spacing-4">Successfully Registered!</p>
-                                <p class="fw-medium spacing-5">We'll notify you via email once your account has been verified.
+                                <p class="fw-medium spacing-5">We'll notify you via email once your account has been
+                                    verified.
                                 </p>
                             </div>
                         </div>
@@ -209,9 +218,40 @@ if ($result->num_rows > 0) {
         </div>
     </div>
 
+    <!-- Only PDF Files Are Allowed Modal -->
+    <div class="modal" id="onlyPDFAllowedModal" data-bs-keyboard="false" data-bs-backdrop="static">
+        <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content">
+                <div class="modal-body">
+                    <div class="d-flex justify-content-end">
+                        <i class="fa fa-solid fa-circle-xmark fa-xl close-mark light-gray" onclick="closeModal()">
+                        </i>
+                    </div>
+                    <div class="text-center">
+                        <div class="col-md-12">
+                            <img src="images/resc/warning.png" alt="Warning Icon">
+                        </div>
+
+                        <div class="row">
+                            <div class="col-md-12 pb-3 pt-4">
+                                <p class="fw-bold fs-3 danger spacing-4 px-2">Only PDF files are allowed</p>
+                                <p class="fw-medium spacing-5 pt-2 px-5 ">Please also ensure the file is no larger than
+                                    25 mb.
+                                    Let's try that again!
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+
     <?php include_once __DIR__ . '/includes/components/all-footer.php'; ?>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script src="../vendor/node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="scripts/register.js"></script>
     <?php
     // Check if registration success flag is set in the session
     if (isset($_SESSION['registrationSuccess']) && $_SESSION['registrationSuccess'] === true) {
@@ -224,12 +264,6 @@ if ($result->num_rows > 0) {
         unset($_SESSION['registrationSuccess']);
     }
     ?>
-
-    <script>
-        function redirectToPage(url) {
-            window.location.href = url;
-        }
-    </script>
 
     <script>document.addEventListener('DOMContentLoaded', function () {
             const emailInput = document.getElementById('email');

--- a/src/register.php
+++ b/src/register.php
@@ -183,8 +183,11 @@ if ($result->num_rows > 0) {
         </div>
     </div>
 
-    <button class="del-no-border px-sm-5 py-sm-1-5 btn-sm fw-bold fs-6 spacing-6" id="reject-btn" data-toggle="modal"
-        data-target="#onlyPDFAllowedModal">Try Only PDF files Button</button>
+    
+    <!-- CODE FOR TESTING ONLY. Remove the comment if no longer needed.
+        
+        <button class="del-no-border px-sm-5 py-sm-1-5 btn-sm fw-bold fs-6 spacing-6" id="reject-btn" data-toggle="modal"
+        data-target="#onlyPDFAllowedModal">Try Only PDF files Button</button> -->
 
 
     <!-- LIST OF MODALS -->

--- a/src/scripts/register.js
+++ b/src/scripts/register.js
@@ -1,0 +1,22 @@
+// MODALS TWEAK
+
+$(document).ready(function () {
+    $("#reject-btn").click(function (event) {
+        $('#onlyPDFAllowedModal').modal('show');
+    });
+
+    $(".close-mark").click(function () {
+        closeModal();
+    });
+});
+
+function closeModal() {
+    $("#onlyPDFAllowedModal").modal("hide");
+}
+
+function redirectToPage(url) {
+    window.location.href = url;
+}
+
+// --- MODALS TWEAK
+


### PR DESCRIPTION
### Overview
This PR adds the 'Only PDF Files Allowed' modal in Registration.

<hr>

### Details
- Added Feature: 'Only PDF Files Allowed' Modal
  -  This modal alerts user when attempting to upload non-PDF files during registration.
- Implemented constraints in both **Successfully Registered Modal** and the **Only PDF Allowed Modal**:
  - `data-bs-keyboard="false"`
  - `data-bs-backdrop="static"`
 
  This prevents modal from closing when users click outside the modal body.

<hr>

### Newly Added Files
`register.js`
- All JavaScript related to the registration process has been consolidated into this file.
- For better maintainability and readability, remaining scripts for back-end/validations within registration.php (now handled by @Carl-Tabuso) should be relocated here.

<hr>

### Artifacts

https://github.com/BSIT-3-1-APPDEV/PUPSRC-AutomatedElectionSystem/assets/135019439/14de88d7-bef6-446f-9678-80cc2ffefd0f

I've used a test button here to simulate how the modal will look. The test button is currently commented out in the commit in line **189-190**.

```
<button class="del-no-border px-sm-5 py-sm-1-5 btn-sm fw-bold fs-6 spacing-6" id="reject-btn" data-toggle="modal" data-target="#onlyPDFAllowedModal">Try Only PDF files Button</button>
```