### PR TITLE
chore: apply activity log- voted, update_email, transfer_org

### DIFF
--- a/src/includes/classes/change-org-class.php
+++ b/src/includes/classes/change-org-class.php
@@ -2,6 +2,7 @@
 
 include_once str_replace('/', DIRECTORY_SEPARATOR, __DIR__ . '/file-utils.php');
 require_once FileUtils::normalizeFilePath(__DIR__ . '/db-connector.php');
+require_once FileUtils::normalizeFilePath(__DIR__ . '/logger.php');
 require_once FileUtils::normalizeFilePath(__DIR__ . '/manage-ip-address.php');
 require_once FileUtils::normalizeFilePath(__DIR__ . '/../session-handler.php');
 require_once FileUtils::normalizeFilePath(__DIR__ . '/../error-reporting.php');
@@ -9,6 +10,7 @@ include_once FileUtils::normalizeFilePath(__DIR__ . '/../default-time-zone.php')
 
 class FormHandler {
     private $conn;
+    private $logger;
 
     public function __construct() {
         $this->conn = DatabaseConnection::connect();
@@ -17,10 +19,10 @@ class FormHandler {
     public function processForm($postData, $fileData) {
         // Retrieve form data
         $voter_id = $postData['voter_id'];
-
+    
         // Fetch user data based on voter ID
         $row = $this->getUserData($voter_id);
-
+    
         if ($row) {
             // Check if organization is selected
             if (isset($postData["org"]) && !empty($postData["org"])) {
@@ -48,32 +50,36 @@ class FormHandler {
     private function processOrganization($org, $fileData, $row, $voter_id) {
         $config = DatabaseConfig::getOrganizationDBConfig($org);
         $connection = new \mysqli($config['host'], $config['username'], $config['password'], $config['database']);
-
+    
         if ($connection->connect_error) {
             die("Connection failed: " . $connection->connect_error);
         }
-
+    
         if (isset($fileData["cor"]) && $fileData["cor"]["error"] == UPLOAD_ERR_OK) {
             $cor_file = $fileData["cor"];
             $upload_directory = "../user_data/$org/cor/";
             $filename = basename($cor_file["name"]);
             $target_file = $upload_directory . $filename;
-
+    
             if (move_uploaded_file($cor_file["tmp_name"], $target_file)) {
-                $this->insertVoterData($connection, $filename, $row, $voter_id);
-                $this->deletePreviousVoterEntry($voter_id);
+                $this->insertVoterData($connection, $filename, $row);
                 $this->updateScoDatabase($filename, $row['email']);
+                $this->invalidatePreviousVoterEntry($voter_id);
+                
+                $logger = new Logger(ROLE_STUDENT_VOTER, TRANSFER_ORG);
+                $logger->logActivity();
+
             } else {
                 // echo "Error: Failed to move uploaded file.";
             }
         } else {
             // echo "Error: File upload failed with error code " . $fileData["cor"]["error"];
         }
-
+    
         $connection->close();
     }
 
-    private function insertVoterData($connection, $filename, $row, $voter_id) {
+    private function insertVoterData($connection, $filename, $row) {
         $last_name = !empty($row['last_name']) ? $row['last_name'] : null;
         $first_name = !empty($row['first_name']) ? $row['first_name'] : null;
         $middle_name = !empty($row['middle_name']) ? $row['middle_name'] : null;
@@ -104,17 +110,18 @@ class FormHandler {
         $stmt->close();
     }
 
-    private function deletePreviousVoterEntry($voter_id) {
-        $stmt_delete = $this->conn->prepare("DELETE FROM voter WHERE voter_id = ?");
-        $stmt_delete->bind_param('s', $voter_id);
+    private function invalidatePreviousVoterEntry($voter_id) {
+        // Prepare the update statement to set account_status to 'invalid'
+        $stmt_update = $this->conn->prepare("UPDATE voter SET account_status = 'invalid' WHERE voter_id = ?");
+        $stmt_update->bind_param('s', $voter_id);
         
-        if ($stmt_delete->execute()) {
-            // echo "Success: Previous entry deleted for voter ID $voter_id.";
+        if ($stmt_update->execute()) {
+            // echo "Success: Account status set to 'invalid' for voter ID $voter_id.";
         } else {
-            // echo "Error: Failed to delete previous entry for voter ID $voter_id.";
+            // echo "Error: Failed to set account status to 'invalid' for voter ID $voter_id.";
         }
-
-        $stmt_delete->close();
+    
+        $stmt_update->close();
     }
 
     private function updateScoDatabase($filename, $email) {

--- a/src/includes/insert-vote.php
+++ b/src/includes/insert-vote.php
@@ -2,6 +2,7 @@
 include_once str_replace('/', DIRECTORY_SEPARATOR, __DIR__ . '/classes/file-utils.php');
 require_once FileUtils::normalizeFilePath('session-handler.php');
 require_once FileUtils::normalizeFilePath('classes/db-connector.php');
+require_once FileUtils::normalizeFilePath('classes/logger.php');
 require_once FileUtils::normalizeFilePath('error-reporting.php');
 
 // Check if the request method is POST
@@ -61,6 +62,10 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
         // Prepare and execute the SQL query to update voter status
         $stmt_vote = $conn->prepare("UPDATE voter SET vote_status = ? WHERE voter_id = ?");
+        
+        $logger = new Logger(ROLE_STUDENT_VOTER, VOTED);
+        $logger->logActivity();
+
         if (!$stmt_vote) {
             die("Error in SQL: " . $conn->error);
         }

--- a/src/includes/process-setting-email.php
+++ b/src/includes/process-setting-email.php
@@ -4,6 +4,7 @@ require_once FileUtils::normalizeFilePath(__DIR__ . '/session-handler.php');
 require_once FileUtils::normalizeFilePath(__DIR__ . '/classes/session-manager.php');
 include_once FileUtils::normalizeFilePath(__DIR__ . '/session-exchange.php');
 require_once FileUtils::normalizeFilePath(__DIR__ . '/classes/db-connector.php');
+require_once FileUtils::normalizeFilePath(__DIR__ . '/classes/logger.php');
 include_once FileUtils::normalizeFilePath(__DIR__ . '/error-reporting.php');
 include_once FileUtils::normalizeFilePath(__DIR__ . '/default-time-zone.php');
 
@@ -91,6 +92,10 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
         $success_org = $stmt_update_org->execute();
 
         if ($success_org) {
+
+            $logger = new Logger(ROLE_STUDENT_VOTER, UPDATE_EMAIL);
+            $logger->logActivity();
+
             echo json_encode(['status' => 'success']);
             exit();
         } else {


### PR DESCRIPTION
chore: apply activity log- voted, update_email,transfer_org

![Screenshot 2024-07-16 183455](https://github.com/user-attachments/assets/24cbadf5-c7f5-4fde-ac99-ac93038f7bd7)

Transfer Org update:
Instead of deleting the voter from the current db, the account_status is set to 'invalid'. 

Requesting to update the link in the `email-sender.php` file, specifically in the sendResetEmail function within the testing branch. Or do I still need to push a commit for this?

![Screenshot 2024-07-16 173551](https://github.com/user-attachments/assets/1c92fce6-2d3e-43fb-9e25-ff489cfbcdfd)


`$updateEmailLink= $this->app_url . "setting-email-update?token=" . urlencode($token) . "&orgName=" . urlencode($orgName);`

Also, I'm requesting to merge my commits from my last PR from 2 days ago into the testing branch. It is not yet reflected, according to my QA. @Carl-Tabuso 

Thank you.